### PR TITLE
Defer callback execution to prevent promise swallowing exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,13 @@ AbstractParser.prototype.parse = function (data, callback, base, filter, graph) 
     self.process(data, pushTriple, base, filter, function (error) {
       // callback API
       if (callback) {
-        if (error) {
-          callback(error)
-        } else {
-          callback(null, graph)
-        }
+        process.nextTick(function() {
+          if (error) {
+            callback(error)
+          } else {
+            callback(null, graph)
+          }
+        })
       }
 
       // Promise API


### PR DESCRIPTION
When using the callback API, if the callback throws an exception the error is swallowed by the promise, making debugging impossible with the callback API.

This patch defers execution of the callback to the next tick to prevent this.  It does not affect the promise API.
