### PR TITLE
Move mocha to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "homepage": "https://github.com/rdf-ext/rdf-parser-abstract",
   "dependencies": {
     "concat-stream": "^1.5.0",
-    "inherits": "^2.0.1",
+    "inherits": "^2.0.1"
+  },
+  "devDependencies": {
     "mocha": "^2.3.3"
   }
 }


### PR DESCRIPTION
This prevents my project being dependent on things like jade unnecessarily.
