### PR TITLE
Migrate to readable stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var concatStream = require('concat-stream')
 var inherits = require('inherits')
-var Readable = require('stream').Readable
+var Readable = require('readable-stream').Readable
 
 function AbstractParser (rdf) {
   this.rdf = rdf

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "homepage": "https://github.com/rdf-ext/rdf-parser-abstract",
   "dependencies": {
     "concat-stream": "^1.5.0",
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "readable-stream": "^2.2.3"
   },
   "devDependencies": {
     "mocha": "^2.3.3",
-    "rdf-ext": "^0.3.0",
-    "readable-stream": "^2.2.3"
+    "rdf-ext": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "mocha": "^2.3.3",
-    "rdf-ext": "^0.3.0"
+    "rdf-ext": "^0.3.0",
+    "readable-stream": "^2.2.3"
   }
 }


### PR DESCRIPTION
If you have "readable-stream" in dependencies it breaks stream.Readable function. And while inheriting you get an error because it can't get prototype of Object.  